### PR TITLE
Add some unit tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [ring/ring-core "1.3.2"]]
   :profiles
-  {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
+  {:dev {:dependencies [[ring/ring-mock "0.2.0"]]}
+   :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
    :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
    :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}})

--- a/test/ring/middleware/accept_test.clj
+++ b/test/ring/middleware/accept_test.clj
@@ -1,7 +1,31 @@
 (ns ring.middleware.accept-test
   (:use clojure.test
-        ring.middleware.accept))
+        ring.middleware.accept)
+  (:require [ring.mock.request :as mock]
+            [ring.util.response :refer [get-header]]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+;; http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+;;
+;; Accept         = "Accept" ":"
+;; #( media-range [ accept-params ] )
+;; media-range    = ( "*/*"
+;;                    | ( type "/" "*" )
+;;                    | ( type "/" subtype )
+;;                    ) *( ";" parameter )
+;; accept-params  = ";" "q" "=" qvalue *( accept-extension )
+;; accept-extension = ";" token [ "=" ( token | quoted-string ) ]
+
+(defn build-request [accept]
+  (-> (mock/request :get "/")
+      (mock/header "accept" accept)))
+
+(defn get-accept [req]
+  (:accept ((wrap-accept identity) req)))
+
+(deftest test-wrap-accept
+  (are [s m] (= (get-accept (build-request s)) m)
+       "*/*" {"*/*" 1.0}
+       "text/plain; charset=utf-8" {"text/plain; charset=utf-8" 1.0}
+       "text/plain, */*" {"text/plain" 1.0, "*/*", 1.0}
+       "application/json" {"application/json" 1.0}
+       "application/vnd.ring.v1+json" {"application/vnd.ring.v1+json" 1.0}))


### PR DESCRIPTION
Hey @weavejester. I recently found myself parsing accept headers in an application, and wanted to use ring-accept to accomplish the task.

I can see the library is a work in progress, so I've stopped work in favour of a quick conversation about any plans you might have.

From what I can tell there's something to work out around ordering lists of accept headers, and potentially parsing version numbers and content types in headers of the form `application/vnd.ring.v1+json`…
